### PR TITLE
Feature/categories endpoints

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -23,6 +23,13 @@ module Api
         headers['Access-Control-Allow-Origin'] = ENV['CORS_WHITELIST']
         headers['Access-Control-Allow-Methods'] = 'GET'
       end
+
+      private
+
+      def load_section
+        @section = Section.find_by_slug(params[:section_slug])
+        render json: {}, status: :not_found and return unless @section
+      end
     end
   end
 end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class CategoriesController < ApiController
       before_action :load_section
+      before_action :load_category, only: [:show]
 
       def index
         @categories = @section.categories.map do |category|
@@ -11,16 +12,14 @@ module Api
       end
 
       def show
-        @category = @section.find_category_by_slug(params[:slug]).
-          to_hash(category_includes)
-        render json: @category
+        render json: @category.to_hash(category_includes)
       end
 
       private
 
-      def load_section
-        @section = Section.find_by_slug(params[:section_slug])
-        render status: :not_found and return unless @section
+      def load_category
+        @category = @section.find_category_by_slug(params[:slug])
+        render json: {}, status: :not_found and return unless @category
       end
 
       def category_includes

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class CategoriesController < ApiController
+      before_action :load_section
+
+      def index
+        @categories = @section.categories.map do |category|
+          category.to_hash(category_includes)
+        end
+        render json: @categories
+      end
+
+      def show
+        @category = @section.find_category_by_slug(params[:slug]).
+          to_hash(category_includes)
+        render json: @category
+      end
+
+      private
+
+      def load_section
+        @section = Section.find_by_slug(params[:section_slug])
+        render status: :not_found and return unless @section
+      end
+
+      def category_includes
+        (params[:includes] || []).map(&:to_sym)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sections_controller.rb
+++ b/app/controllers/api/v1/sections_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class SectionsController < ApiController
+      before_action :load_section, only: [:show]
+
       def index
         @sections = Section.all.map do |section|
           section.to_hash(section_includes)
@@ -9,12 +11,15 @@ module Api
       end
 
       def show
-        @section = Section.find_by_slug(params[:slug]).
-          to_hash(section_includes)
-        render json: @section
+        render json: @section.to_hash(section_includes)
       end
 
       private
+
+      def load_section
+        @section = Section.find_by_slug(params[:slug])
+        render json: {}, status: :not_found and return unless @section
+      end
 
       def section_includes
         (params[:includes] || []).map(&:to_sym)

--- a/app/controllers/api/v1/sections_controller.rb
+++ b/app/controllers/api/v1/sections_controller.rb
@@ -2,12 +2,15 @@ module Api
   module V1
     class SectionsController < ApiController
       def index
-        @sections = Section.all(section_includes)
+        @sections = Section.all.map do |section|
+          section.to_hash(section_includes)
+        end
         render json: @sections
       end
 
       def show
-        @section = Section.find_by_slug(params[:slug], section_includes)
+        @section = Section.find_by_slug(params[:slug]).
+          to_hash(section_includes)
         render json: @section
       end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,13 +1,15 @@
 class Category
   include ActiveModel::Model
   include ActiveModel::Serialization
-  attr_reader :title, :slug, :targets
+  attr_reader :title, :slug, :optional, :order, :targets
 
   # @param category_config [Hash]
   # @option category_config :categories [Array<Hash>]
   def initialize(category_config)
     @title = category_config[:title]
     @slug = category_config[:slug]
+    @optional = category_config[:optional]
+    @order = category_config[:order]
     @targets = category_config[:targets].map do |target_config|
       # TODO: targets are dynamic
       Target.new(target_config.symbolize_keys)
@@ -15,7 +17,7 @@ class Category
   end
 
   def attributes
-    {'title' => nil, 'slug' => nil}
+    {'title' => nil, 'slug' => nil, 'optional' => nil}
   end
 
   # @param includes [Array<Symbol>]
@@ -26,7 +28,9 @@ class Category
   end
 
   def self.serialization_options(includes)
-    default_serialization_options = {methods: [:title, :slug]}
+    default_serialization_options = {
+      methods: [:title, :slug, :optional, :order]
+    }
     custom_serialization_options =
       if includes.include?(:targets)
         {include: :targets}

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,4 +17,22 @@ class Category
   def attributes
     {'title' => nil, 'slug' => nil}
   end
+
+  # @param includes [Array<Symbol>]
+  def to_hash(includes = [])
+    serializable_hash(
+      Category.serialization_options(includes)
+    )
+  end
+
+  def self.serialization_options(includes)
+    default_serialization_options = {methods: [:title, :slug]}
+    custom_serialization_options =
+      if includes.include?(:targets)
+        {include: :targets}
+      else
+        {}
+      end
+    default_serialization_options.merge(custom_serialization_options)
+  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -8,9 +8,10 @@ class Section
   def initialize(section_config)
     @title = section_config[:title]
     @slug = section_config[:slug]
-    @categories = section_config[:categories].map do |category_config|
-      Category.new(category_config.symbolize_keys)
-    end
+    @categories = section_config[:categories].
+      map.with_index do |category_config, idx|
+        Category.new(category_config.symbolize_keys.merge(order: idx))
+      end
   end
 
   def attributes

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -17,23 +17,28 @@ class Section
     {'title' => nil, 'slug' => nil}
   end
 
-  # @param includes [Array<String>]
-  def self.all(includes = [])
-    Configuration.instance.sections.map do |section|
-      section.serializable_hash(
-        serialization_options(includes)
-      )
+  def self.all
+    Configuration.instance.sections
+  end
+
+  # @param slug [String]
+  def self.find_by_slug(slug)
+    Configuration.instance.sections.find do |section|
+      section.slug == slug
     end
   end
 
   # @param slug [String]
-  def self.find_by_slug(slug, includes = [])
-    result = Configuration.instance.sections.find do |section|
+  def find_category_by_slug(slug)
+    categories.find do |section|
       section.slug == slug
     end
-    return nil unless result
-    result.serializable_hash(
-      serialization_options(includes)
+  end
+
+  # @param includes [Array<Symbol>]
+  def to_hash(includes = [])
+    serializable_hash(
+      Section.serialization_options(includes)
     )
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :sections, param: :slug, only: [:index, :show]
+      resources :sections, param: :slug, only: [:index, :show] do
+        resources :categories, param: :slug, only: [:index, :show]
+      end
 
       get 'auth/login', to: 'auth#login'
       get 'auth/logout', to: 'auth#logout'

--- a/db/configuration.json
+++ b/db/configuration.json
@@ -7,6 +7,7 @@
             {
                "title":"NDC Targets",
                "slug":"ndc_targets",
+               "optional": false,
                "targets":[
                   {
                      "title":"GHG Target",
@@ -157,6 +158,7 @@
                   {
                      "title":"Non-GHG Target",
                      "slug":"ghg_target",
+                     "optional": false,
                      "indicators":[
                         {
                            "title":"Theme",
@@ -200,16 +202,19 @@
             {
                "title": "Policies and actions",
                "slug": "policies_and_actions",
+               "optional": false,
                "targets": []
             },
             {
                "title": "User-defined targets",
                "slug": "user_defined_targets",
+               "optional": true,
                "targets": []
             },
             {
                "title":"Methodology",
                "slug":"methodology",
+               "optional": false,
                "targets":[
                   {
                      "title":"Scope and coverage",
@@ -361,21 +366,36 @@
             {
                "title": "NDC Targets",
                "slug": "ndc_targets",
-               "targets": []
+               "optional": false,
+               "targets":[
+                  {
+                     "title":"GHG Target",
+                     "slug":"ghg_target",
+                     "indicators":[]
+                  },
+                  {
+                     "title":"Non-GHG Target",
+                     "slug":"ghg_target",
+                     "indicators":[]
+                  }
+               ]
             },
             {
                "title": "Policies and actions",
                "slug": "policies_and_actions",
+               "optional": false,
                "targets": []
             },
             {
                "title": "Finance and support",
                "slug": "finance_and_support",
+               "optional": false,
                "targets": []
             },
             {
                "title": "Assessing progress",
                "slug": "assessing_progress",
+               "optional": false,
                "targets": []
             }
          ]

--- a/docs/tracking-tool-for-climate-watch/api.md
+++ b/docs/tracking-tool-for-climate-watch/api.md
@@ -1,0 +1,152 @@
+# API
+
+## Sections
+
+### `GET /api/v1/sections`
+
+#### Parameters:
+- `includes` - array of nested resources to include. Available values: `categories`, `targets`
+
+#### Examples:
+
+- `GET /api/v1/sections`
+
+```
+[
+   {
+      "title":"Planning",
+      "slug":"planning"
+   },
+   {
+      "title":"Tracking",
+      "slug":"tracking"
+   }
+]
+```
+
+- `GET /api/v1/sections?includes[]=categories`
+
+```
+[
+   {
+      "title":"Planning",
+      "slug":"planning",
+      "categories":[
+         {
+            "title":"NDC Targets",
+            "slug":"ndc_targets"
+         },
+         ...
+      ]
+   },
+  ...
+]
+```
+
+- `/api/v1/sections?includes[]=categories&includes[]=targets`
+
+```
+[
+   {
+      "title":"Planning",
+      "slug":"planning",
+      "categories":[
+         {
+            "title":"NDC Targets",
+            "slug":"ndc_targets",
+            "targets":[
+               {
+                  "title":"GHG Target",
+                  "slug":"ghg_target"
+               },
+               {
+                  "title":"Non-GHG Target",
+                  "slug":"ghg_target"
+               }
+            ]
+         },
+         ...
+      ]
+   },
+  ...
+]
+```
+
+### `GET /api/v1/sections/:slug`
+
+#### Parameters:
+- same as for collection
+
+#### Examples:
+
+- `GET /api/v1/sections/planning`
+
+```
+   {
+      "title":"Planning",
+      "slug":"planning"
+   }
+```
+
+## Categories
+
+### `GET /api/v1/sections/:section_slug/categories`
+
+#### Parameters:
+- `includes` - array of nested resources to include. Available values: `targets`
+
+#### Examples:
+
+- `GET /api/v1/sections/planning/categories`
+
+```
+[
+   {
+      "title":"NDC Targets",
+      "slug":"ndc_targets"
+   },
+   {
+      "title":"Policies and actions",
+      "slug":"policies_and_actions"
+   },
+   ...
+]
+```
+
+- `GET /api/v1/sections/planning/categories?includes[]=targets`
+
+```
+[
+   {
+      "title":"NDC Targets",
+      "slug":"ndc_targets",
+      "targets":[
+         {
+            "title":"GHG Target",
+            "slug":"ghg_target"
+         },
+         {
+            "title":"Non-GHG Target",
+            "slug":"ghg_target"
+         }
+      ]
+   },
+   ...
+]
+```
+
+### `GET /api/v1/sections/:section_slug/categories/:slug`
+
+#### Parameters:
+- same as for collection
+
+#### Examples:
+
+- `GET /api/v1/sections/planning/categories/ndc_targets`
+
+```
+{
+   "title":"NDC Targets",
+   "slug":"ndc_targets"
+}
+```

--- a/docs/tracking-tool-for-climate-watch/api.md
+++ b/docs/tracking-tool-for-climate-watch/api.md
@@ -103,11 +103,15 @@
 [
    {
       "title":"NDC Targets",
-      "slug":"ndc_targets"
+      "slug":"ndc_targets",
+      "optional":false,
+      "order": 0
    },
    {
       "title":"Policies and actions",
-      "slug":"policies_and_actions"
+      "slug":"policies_and_actions",
+      "optional":false,
+      "order": 1
    },
    ...
 ]
@@ -120,6 +124,8 @@
    {
       "title":"NDC Targets",
       "slug":"ndc_targets",
+      "optional":false,
+      "order": 0,
       "targets":[
          {
             "title":"GHG Target",
@@ -147,6 +153,8 @@
 ```
 {
    "title":"NDC Targets",
-   "slug":"ndc_targets"
+   "slug":"ndc_targets",
+   "optional":false,
+   "order": 0
 }
 ```

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Api::V1::CategoriesController, type: :controller do
       get :index, params: {section_slug: 'planning', includes: [:targets]}
       expect(@response).to match_response_schema('categories_with_targets')
     end
+
+    it 'responds with not found' do
+      get :index, params: {section_slug: 'foobar'}
+      expect(@response).to have_http_status(:not_found)
+    end
   end
 
   describe 'GET show' do
@@ -22,6 +27,16 @@ RSpec.describe Api::V1::CategoriesController, type: :controller do
     it 'includes targets' do
       get :show, params: {section_slug: 'planning', slug: 'ndc_targets', includes: [:targets]}
       expect(@response).to match_response_schema('category_with_targets')
+    end
+
+    it 'responds with not found' do
+      get :show, params: {section_slug: 'foobar', slug: 'ndc_targets'}
+      expect(@response).to have_http_status(:not_found)
+    end
+
+    it 'responds with not found' do
+      get :show, params: {section_slug: 'planning', slug: 'foobar'}
+      expect(@response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CategoriesController, type: :controller do
+  describe 'GET index' do
+    it 'renders title and slug for each category' do
+      get :index, params: {section_slug: 'planning'}
+      expect(@response).to match_response_schema('categories')
+    end
+
+    it 'includes targets' do
+      get :index, params: {section_slug: 'planning', includes: [:targets]}
+      expect(@response).to match_response_schema('categories_with_targets')
+    end
+  end
+
+  describe 'GET show' do
+    it 'renders title and slug for category' do
+      get :show, params: {section_slug: 'planning', slug: 'ndc_targets'}
+      expect(@response).to match_response_schema('category')
+    end
+
+    it 'includes targets' do
+      get :show, params: {section_slug: 'planning', slug: 'ndc_targets', includes: [:targets]}
+      expect(@response).to match_response_schema('category_with_targets')
+    end
+  end
+end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe Api::V1::SectionsController, type: :controller do
       get :show, params: {slug: 'planning', includes: [:targets]}
       expect(@response).to match_response_schema('section_with_targets')
     end
+
+    it 'responds with not found' do
+      get :show, params: {slug: 'foobar'}
+      expect(@response).to have_http_status(:not_found)
+    end
   end
 end

--- a/spec/support/api/schemas/categories.json
+++ b/spec/support/api/schemas/categories.json
@@ -24,6 +24,24 @@
         "examples": [
           "ndc_targets"
         ]
+      },
+      "optional": {
+        "$id": "http://example.com/example.json/items/properties/optional",
+        "type": "boolean",
+        "title": "The Optional Schema ",
+        "default": false,
+        "examples": [
+          false
+        ]
+      },
+      "order": {
+        "$id": "http://example.com/example.json/items/properties/order",
+        "type": "integer",
+        "title": "The Order Schema ",
+        "default": 0,
+        "examples": [
+          0
+        ]
       }
     }
   }

--- a/spec/support/api/schemas/categories.json
+++ b/spec/support/api/schemas/categories.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://example.com/example.json",
+  "type": "array",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "items": {
+    "$id": "http://example.com/example.json/items",
+    "type": "object",
+    "properties": {
+      "title": {
+        "$id": "http://example.com/example.json/items/properties/title",
+        "type": "string",
+        "title": "The Title Schema ",
+        "default": "",
+        "examples": [
+          "NDC Targets"
+        ]
+      },
+      "slug": {
+        "$id": "http://example.com/example.json/items/properties/slug",
+        "type": "string",
+        "title": "The Slug Schema ",
+        "default": "",
+        "examples": [
+          "ndc_targets"
+        ]
+      }
+    }
+  }
+}

--- a/spec/support/api/schemas/categories_with_targets.json
+++ b/spec/support/api/schemas/categories_with_targets.json
@@ -25,6 +25,24 @@
           "ndc_targets"
         ]
       },
+      "optional": {
+        "$id": "http://example.com/example.json/items/properties/optional",
+        "type": "boolean",
+        "title": "The Optional Schema ",
+        "default": false,
+        "examples": [
+          false
+        ]
+      },
+      "order": {
+        "$id": "http://example.com/example.json/items/properties/order",
+        "type": "integer",
+        "title": "The Order Schema ",
+        "default": 0,
+        "examples": [
+          0
+        ]
+      },
       "targets": {
         "$id": "http://example.com/example.json/items/properties/targets",
         "type": "array",

--- a/spec/support/api/schemas/categories_with_targets.json
+++ b/spec/support/api/schemas/categories_with_targets.json
@@ -1,0 +1,58 @@
+{
+  "$id": "http://example.com/example.json",
+  "type": "array",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "items": {
+    "$id": "http://example.com/example.json/items",
+    "type": "object",
+    "properties": {
+      "title": {
+        "$id": "http://example.com/example.json/items/properties/title",
+        "type": "string",
+        "title": "The Title Schema ",
+        "default": "",
+        "examples": [
+          "NDC Targets"
+        ]
+      },
+      "slug": {
+        "$id": "http://example.com/example.json/items/properties/slug",
+        "type": "string",
+        "title": "The Slug Schema ",
+        "default": "",
+        "examples": [
+          "ndc_targets"
+        ]
+      },
+      "targets": {
+        "$id": "http://example.com/example.json/items/properties/targets",
+        "type": "array",
+        "items": {
+          "$id": "http://example.com/example.json/items/properties/targets/items",
+          "type": "object",
+          "properties": {
+            "title": {
+              "$id": "http://example.com/example.json/items/properties/targets/items/properties/title",
+              "type": "string",
+              "title": "The Title Schema ",
+              "default": "",
+              "examples": [
+                "GHG Target"
+              ]
+            },
+            "slug": {
+              "$id": "http://example.com/example.json/items/properties/targets/items/properties/slug",
+              "type": "string",
+              "title": "The Slug Schema ",
+              "default": "",
+              "examples": [
+                "ghg_target"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/api/schemas/category.json
+++ b/spec/support/api/schemas/category.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "properties": {
+    "title": {
+      "$id": "/properties/title",
+      "type": "string",
+      "title": "The Title Schema ",
+      "default": "",
+      "examples": [
+        "NDC Targets"
+      ]
+    },
+    "slug": {
+      "$id": "/properties/slug",
+      "type": "string",
+      "title": "The Slug Schema ",
+      "default": "",
+      "examples": [
+        "ndc_targets"
+      ]
+    }
+  }
+}

--- a/spec/support/api/schemas/category.json
+++ b/spec/support/api/schemas/category.json
@@ -21,6 +21,24 @@
       "examples": [
         "ndc_targets"
       ]
+    },
+    "optional": {
+      "$id": "/properties/optional",
+      "type": "boolean",
+      "title": "The Optional Schema ",
+      "default": false,
+      "examples": [
+        false
+      ]
+    },
+    "order": {
+      "$id": "/properties/order",
+      "type": "integer",
+      "title": "The Order Schema ",
+      "default": 0,
+      "examples": [
+        0
+      ]
     }
   }
 }

--- a/spec/support/api/schemas/category_with_targets.json
+++ b/spec/support/api/schemas/category_with_targets.json
@@ -22,6 +22,24 @@
         "ndc_targets"
       ]
     },
+    "optional": {
+      "$id": "/properties/optional",
+      "type": "boolean",
+      "title": "The Optional Schema ",
+      "default": false,
+      "examples": [
+        false
+      ]
+    },
+    "order": {
+      "$id": "/properties/order",
+      "type": "integer",
+      "title": "The Order Schema ",
+      "default": 0,
+      "examples": [
+        0
+      ]
+    },
     "targets": {
       "$id": "/properties/targets",
       "type": "array",

--- a/spec/support/api/schemas/category_with_targets.json
+++ b/spec/support/api/schemas/category_with_targets.json
@@ -1,0 +1,54 @@
+{
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "properties": {
+    "title": {
+      "$id": "/properties/title",
+      "type": "string",
+      "title": "The Title Schema ",
+      "default": "",
+      "examples": [
+        "NDC Targets"
+      ]
+    },
+    "slug": {
+      "$id": "/properties/slug",
+      "type": "string",
+      "title": "The Slug Schema ",
+      "default": "",
+      "examples": [
+        "ndc_targets"
+      ]
+    },
+    "targets": {
+      "$id": "/properties/targets",
+      "type": "array",
+      "items": {
+        "$id": "/properties/targets/items",
+        "type": "object",
+        "properties": {
+          "title": {
+            "$id": "/properties/targets/items/properties/title",
+            "type": "string",
+            "title": "The Title Schema ",
+            "default": "",
+            "examples": [
+              "GHG Target"
+            ]
+          },
+          "slug": {
+            "$id": "/properties/targets/items/properties/slug",
+            "type": "string",
+            "title": "The Slug Schema ",
+            "default": "",
+            "examples": [
+              "ghg_target"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/api/schemas/section_with_categories.json
+++ b/spec/support/api/schemas/section_with_categories.json
@@ -46,6 +46,15 @@
             "examples": [
               "ndc_targets"
             ]
+          },
+          "optional": {
+            "$id": "/properties/categories/items/properties/optional",
+            "type": "boolean",
+            "title": "The Optional Schema ",
+            "default": false,
+            "examples": [
+              false
+            ]
           }
         }
       }

--- a/spec/support/api/schemas/section_with_targets.json
+++ b/spec/support/api/schemas/section_with_targets.json
@@ -47,6 +47,15 @@
               "ndc_targets"
             ]
           },
+          "optional": {
+            "$id": "/properties/categories/items/properties/optional",
+            "type": "boolean",
+            "title": "The Optional Schema ",
+            "default": false,
+            "examples": [
+              false
+            ]
+          },
           "targets": {
             "$id": "/properties/categories/items/properties/targets",
             "type": "array",

--- a/spec/support/api/schemas/sections_with_categories.json
+++ b/spec/support/api/schemas/sections_with_categories.json
@@ -49,6 +49,15 @@
               "examples": [
                 "ndc_targets"
               ]
+            },
+            "optional": {
+              "$id": "http://example.com/example.json/items/properties/categories/items/properties/optional",
+              "type": "boolean",
+              "title": "The Optional Schema ",
+              "default": false,
+              "examples": [
+                false
+              ]
             }
           }
         }

--- a/spec/support/api/schemas/sections_with_targets.json
+++ b/spec/support/api/schemas/sections_with_targets.json
@@ -50,6 +50,15 @@
                 "ndc_targets"
               ]
             },
+            "optional": {
+              "$id": "http://example.com/example.json/items/properties/categories/items/properties/optional",
+              "type": "boolean",
+              "title": "The Optional Schema ",
+              "default": false,
+              "examples": [
+                false
+              ]
+            },
             "targets": {
               "$id": "http://example.com/example.json/items/properties/categories/items/properties/targets",
               "type": "array",


### PR DESCRIPTION
Adds collection and member GET endpoints for categories:

- `GET /api/v1/sections/:section_slug/categories`
- `GET /api/v1/sections/:section_slug/categories/:slug`

Description in docs. Please note it does not return the `active` property yet, because that's part of per-report customisation which will come later.

