### PR TITLE
Feature/associate reports with users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   gem 'rspec-rails', '~> 3.7'
-  gem 'factory_bot_rails'
+  gem 'factory_bot_rails', '~> 4.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ DEPENDENCIES
   devise
   devise_invitable
   dotenv-rails
-  factory_bot_rails
+  factory_bot_rails (~> 4.0)
   jbuilder (~> 2.5)
   json-schema
   letter_opener

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -29,7 +29,7 @@ module Api
       private
 
       def load_report
-        @report = Report.find_or_create_by({}) # TODO
+        @report = Report.find_or_create_by(user_id: current_user.id)
         render json: {}, status: :not_found and return unless @report
       end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,4 +1,5 @@
 class Report < ApplicationRecord
+  belongs_to :user
   has_many :categories, dependent: :delete_all
 
   # @param years [Array<Integer>]

--- a/db/migrate/20180426132904_add_user_id_to_reports.rb
+++ b/db/migrate/20180426132904_add_user_id_to_reports.rb
@@ -1,0 +1,6 @@
+class AddUserIdToReports < ActiveRecord::Migration[5.1]
+  def change
+    Report.delete_all
+    add_reference :reports, :user, null: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425110113) do
+ActiveRecord::Schema.define(version: 20180426132904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,8 @@ ActiveRecord::Schema.define(version: 20180425110113) do
   create_table "reports", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
   create_table "targets", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,14 +7,14 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 if Rails.env.development?
-  User.create!(
+  admin_user = User.create!(
     email: 'admin@example.com',
     name: 'Admin User',
     is_admin: true,
     password: 'password',
     password_confirmation: 'password'
   )
-  User.create!(
+  api_user = User.create!(
     email: 'user@example.com',
     name: 'API user Brazil',
     country_iso_code: 'BR',
@@ -23,6 +23,6 @@ if Rails.env.development?
     password_confirmation: 'password'
   )
 
-  default_report = Report.find_or_create_by({}) # TODO
+  default_report = Report.find_or_create_by({user_id: api_user.id})
   default_report.initialize_categories([2018], true)
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :category do
+    report
   end
 end

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :report do
+    user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name 'John Doe'
-    email 'john.doe@email.com'
+    sequence(:email) { |n| "person#{n}@example.com" }
     is_admin false
     password 'password123'
   end

--- a/spec/services/get_all_categories_spec.rb
+++ b/spec/services/get_all_categories_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe GetAllCategories, type: :service do
+  include_context 'report with categories'
+
+  describe '#call' do
+    let(:section) { planning_section }
+    let(:static_category) {
+      section.find_category_by_slug('user_defined_targets')
+    }
+    let(:service) { GetAllCategories.new(default_report, planning_section) }
+    let(:categories) { service.call(2018, []) }
+    let(:category) { categories.detect { |c| c['slug'] == static_category.slug }}
+    context 'when default categories enabled' do
+      it 'extra category is not active' do
+        expect(category[:active]).to be false
+      end
+    end
+    context 'when additional categories enabled' do
+      before(:each) {
+        default_report.categories.create(
+          section_slug: section.slug, slug: static_category.slug
+        )
+      }
+      it 'extra category is active' do
+        expect(category[:active]).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Links report objects with users and therefore allows to get rid of the default ownerless report in favour of `current_user`'s report object.

`bundle exec rake db:drop db:create db:migrate db:seed` - will create a user `user@example.com` associated with Brazil and initialize the report.