### PR TITLE
Fix/reporting reload

### DIFF
--- a/app/javascript/app/components/report-menu/report-menu-styles.scss
+++ b/app/javascript/app/components/report-menu/report-menu-styles.scss
@@ -23,6 +23,7 @@
     color: $theme-color;
     text-decoration: none;
     padding-left: 20px;
+    display: inline-block;
 
     &.active::before {
       content: "";

--- a/app/javascript/app/providers/sections.provider.js
+++ b/app/javascript/app/providers/sections.provider.js
@@ -2,10 +2,10 @@ import { apiActionCreator, get } from '../services/api.service';
 
 const path =
   'sections?includes[]=categories&includes[]=targets&includes[]=indicators';
-
-export async function getSectionsThunk(dispatch, getState) {
+// Remove the force attribute when the reducers are updated and the data has only one source
+export async function getSectionsThunk(dispatch, getState, force = false) {
   const isSectionsEmpty = getState().sections.length === 0;
-  if (isSectionsEmpty) {
+  if (isSectionsEmpty || force) {
     dispatch(fetchSections());
   }
 }

--- a/app/javascript/app/router.js
+++ b/app/javascript/app/router.js
@@ -64,7 +64,9 @@ export const routes = {
     label: 'Reporting',
     path: '/reporting',
     component: Reporting,
-    thunk: dispatchPreFetchThunks(getSectionsThunk)
+    thunk: (dispatch, getState) => {
+      getSectionsThunk(dispatch, getState, true);
+    }
   },
   [LOGIN]: {
     path: '/login',
@@ -93,7 +95,9 @@ export const routes = {
 const customRestoreScroll = restoreScroll({
   shouldUpdateScroll: (prev, locationState) => {
     if (!locationState.query) return true;
-    if (locationState.kind === 'push' && !locationState.payload.query) { return false; } // Don't scroll if changing the anchor while scrolling
+    if (locationState.kind === 'push' && !locationState.payload.query) {
+      return false;
+    } // Don't scroll if changing the anchor while scrolling
     const id = `${locationState.query.category}+${locationState.query.target}`;
     if (!id || prev.search === locationState.search) return true;
     const element = document.getElementById(id);


### PR DESCRIPTION
This is a temporal solution until the reducers are updated and we have a unique source of data
- The reporting was not reloading after a PATCH

Extra: 
Fix some indentation on the menu