### PR TITLE
Feature/planning ndc targets description type year

### DIFF
--- a/app/javascript/app/components/target/target-component.jsx
+++ b/app/javascript/app/components/target/target-component.jsx
@@ -17,7 +17,9 @@ const Target = ({
   summary,
   editActionLink,
   handleRemoveAction,
-  infoText
+  infoText,
+  targetType,
+  targetYear
 }) => (
   <div className={theme.borderStyles}>
     <div className={theme.wrapper}>
@@ -27,6 +29,18 @@ const Target = ({
           {infoText && <InfoIcon text={infoText} className={styles.infoIcon} />}
         </div>
         {summary && <p className={theme.summary}>{summary}</p>}
+        {targetType && (
+          <div className={styles.metadataItem}>
+            <p className={styles.metadataTitle}>Target type</p>
+            <p className={styles.metadataValue}>{targetType}</p>
+          </div>
+        )}
+        {targetYear && (
+          <div className={styles.metadataItem}>
+            <p className={styles.metadataTitle}>Target year</p>
+            <p className={styles.metadataValue}>{targetYear}</p>
+          </div>
+        )}
       </div>
       <div className={theme.buttonContainer}>
         {editActionLink && (
@@ -50,7 +64,9 @@ Target.propTypes = {
   theme: PropTypes.object,
   title: PropTypes.string,
   infoText: PropTypes.string,
-  summary: PropTypes.string
+  summary: PropTypes.string,
+  targetType: PropTypes.string,
+  targetYear: PropTypes.string
 };
 
 Target.defaultProps = {

--- a/app/javascript/app/components/target/target-component.jsx
+++ b/app/javascript/app/components/target/target-component.jsx
@@ -19,16 +19,21 @@ const Target = ({
   handleRemoveAction,
   infoText,
   targetType,
-  targetYear
+  targetYear,
+  summaryOnTooltip
 }) => (
   <div className={theme.borderStyles}>
     <div className={theme.wrapper}>
       <div className={theme.infoContainer}>
         <div className={styles.nameWrapper}>
           <span className={theme.name}>{title}</span>
-          {infoText && <InfoIcon text={infoText} className={styles.infoIcon} />}
+          {summary &&
+          summaryOnTooltip && (
+          <InfoIcon text={infoText} className={styles.infoIcon} />
+            )}
         </div>
-        {summary && <p className={theme.summary}>{summary}</p>}
+        {summary &&
+        !summaryOnTooltip && <p className={theme.summary}>{summary}</p>}
         {targetType && (
           <div className={styles.metadataItem}>
             <p className={styles.metadataTitle}>Target type</p>
@@ -66,12 +71,12 @@ Target.propTypes = {
   infoText: PropTypes.string,
   summary: PropTypes.string,
   targetType: PropTypes.string,
-  targetYear: PropTypes.string
+  targetYear: PropTypes.string,
+  summaryOnTooltip: PropTypes.bool
 };
 
 Target.defaultProps = {
-  hasRemoveAction: false,
-  hasEditAction: false
+  summaryOnTooltip: false
 };
 
 export default themr('Target', styles)(Target);

--- a/app/javascript/app/components/target/target-styles.scss
+++ b/app/javascript/app/components/target/target-styles.scss
@@ -18,11 +18,11 @@
 .nameWrapper {
   display: flex;
   align-items: baseline;
-  margin-bottom: 10px;
+  margin-bottom: $card-content-margin;
 }
 
 .name {
-  font-size: 1.375rem; // 22px / 16px
+  font-size: $font-size-big;
   color: $theme-color;
 }
 
@@ -31,7 +31,23 @@
 }
 
 .summary {
+  margin-bottom: $card-content-margin;
+}
+
+.metadataItem {
+  display: inline-block;
+  padding-right: 45px;
+}
+
+.summary,
+.metadataValue {
   color: $theme-color;
+}
+
+.metadataTitle {
+  color: $dark-gray;
+  font-size: $font-size-sm;
+  margin-bottom: 5px;
 }
 
 .buttonContainer {

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -8,7 +8,13 @@ import styles from './planning-styles.scss';
 
 class Planning extends PureComponent {
   render() {
-    const { categories, selectedCategory, handleOnSearch, search } = this.props;
+    const {
+      categories,
+      selectedCategory,
+      handleOnSearch,
+      search,
+      getTargetMetaData
+    } = this.props;
     const isNotNdcTargetsCategory =
       categories && selectedCategory && selectedCategory !== 'ndc_targets';
     return (
@@ -39,6 +45,8 @@ class Planning extends PureComponent {
                     summary={target.summary}
                     editActionLink={`/planning/${selectedCategory}/${target.slug}`}
                     infoText="text"
+                    targetType={getTargetMetaData(target, 'ghg_target_type')}
+                    targetYear={getTargetMetaData(target, 'M_TarYr')}
                   />
                 ))}
           </div>
@@ -52,7 +60,8 @@ Planning.propTypes = {
   selectedCategory: PropTypes.string,
   search: PropTypes.string,
   categories: PropTypes.array,
-  handleOnSearch: PropTypes.func
+  handleOnSearch: PropTypes.func,
+  getTargetMetaData: PropTypes.func
 };
 
 export default Planning;

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -44,7 +44,7 @@ class Planning extends PureComponent {
                     key={target.slug}
                     summary={target.summary}
                     editActionLink={`/planning/${selectedCategory}/${target.slug}`}
-                    infoText="text"
+                    infoText={target.info}
                     targetType={getTargetMetaData(target, 'ghg_target_type')}
                     targetYear={getTargetMetaData(target, 'M_TarYr')}
                   />

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -44,7 +44,6 @@ class Planning extends PureComponent {
                     key={target.slug}
                     summary={target.summary}
                     editActionLink={`/planning/${selectedCategory}/${target.slug}`}
-                    infoText={target.info}
                     targetType={getTargetMetaData(target, 'ghg_target_type')}
                     targetYear={getTargetMetaData(target, 'M_TarYr')}
                   />

--- a/app/javascript/app/pages/planning/planning.js
+++ b/app/javascript/app/pages/planning/planning.js
@@ -27,9 +27,17 @@ class PlanningContainer extends PureComponent {
       updateUrlParam({ name: 'search', value: query });
     };
 
+    function getTargetMetaData(target, slug) {
+      const targetMetaDataField = target.indicators.find(
+        ind => ind.slug === slug
+      );
+      return targetMetaDataField && targetMetaDataField.values[0].value;
+    }
+
     return createElement(PlanningComponent, {
       ...this.props,
-      handleOnSearch
+      handleOnSearch,
+      getTargetMetaData
     });
   }
 }


### PR DESCRIPTION
This PR adds `Target type` and `Target year` to Planning/ NDCs targets overview.
[Pivotal](https://www.pivotaltracker.com/story/show/159073355)
[Designs](https://projects.invisionapp.com/share/Z5GDJP09ACQ#/screens/285504241)

There are a couple of questions that pop up: 
-  The info button is not showing on the designs (neither on inVision nor in Zeplin), I'm not being able to find the basecamp thread that lead to its inclusion. Should we keep it?
-  @Bluesmile82 I have not created a component for the target metadata, but if this pattern (title-value) gets used in more places in the future may worth to create one. 

![image](https://user-images.githubusercontent.com/6906348/42814461-977e10d8-89c4-11e8-886c-15ffb855954d.png)
