### PR TITLE
Add target reporting percentage data to tracking target

### DIFF
--- a/app/javascript/app/components/tracking-target/tracking-target-component.jsx
+++ b/app/javascript/app/components/tracking-target/tracking-target-component.jsx
@@ -51,7 +51,11 @@ const Target = ({
         <Fragment>
           <ProgressBar progress={reportedPercentage} />
           <Button theme={yellowButtonTheme} link={editActionLink}>
-            Report
+            {reportedPercentage > 0 && reportedPercentage < 100 ? (
+              'Continue tracking'
+            ) : (
+              'Report'
+            )}
           </Button>
         </Fragment>
       )}

--- a/app/javascript/app/components/tracking-target/tracking-target-component.jsx
+++ b/app/javascript/app/components/tracking-target/tracking-target-component.jsx
@@ -50,7 +50,7 @@ const Target = ({
       ) : (
         <Fragment>
           <ProgressBar progress={reportedPercentage} />
-          <Button theme={yellowButtonTheme} onClick={() => true}>
+          <Button theme={yellowButtonTheme} link={editActionLink}>
             Report
           </Button>
         </Fragment>

--- a/app/javascript/app/pages/tracking/tracking-component.jsx
+++ b/app/javascript/app/pages/tracking/tracking-component.jsx
@@ -60,7 +60,7 @@ class Tracking extends PureComponent {
                     title={target.title}
                     summary={target.summary}
                     updatedAt={target.updated_at}
-                    reportedPercentage={100}
+                    reportedPercentage={target.reported_percentage}
                     editActionLink={`/tracking/${selectedCategory}/${target.slug}`}
                   />
                 ))}


### PR DESCRIPTION
This was a small one. 
[Pivotal](https://www.pivotaltracker.com/story/show/158943185)
Changed hard coded data with API data to display the progress bar on  `Tracking > NDC Targets`

![image](https://user-images.githubusercontent.com/6906348/42831734-7186a392-89ef-11e8-8d35-fd50c67a9852.png)
