### PR TITLE
Feature/add search bars

### DIFF
--- a/app/javascript/app/pages/edit-target/edit-target-styles.scss
+++ b/app/javascript/app/pages/edit-target/edit-target-styles.scss
@@ -7,10 +7,6 @@
 .actions {
   @include row(3);
 
-  > :first-child {
-    @include column-offset(9, $gutters: true);
-  }
-
   padding-top: 10px;
   padding-bottom: 40px;
 }

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -16,7 +16,8 @@ class Planning extends PureComponent {
       selectedCategory,
       handleOnSearch,
       search,
-      getTargetMetaData
+      getTargetMetaData,
+      getSelectedCategoryTitle
     } = this.props;
     const hasAddTarget =
       categories &&
@@ -34,7 +35,10 @@ class Planning extends PureComponent {
               })}
             >
               <Search
-                placeholder="Search something"
+                placeholder={`Filter ${getSelectedCategoryTitle(
+                  categories,
+                  selectedCategory
+                )}`}
                 value={search}
                 onChange={handleOnSearch}
                 className={styles.search}
@@ -73,7 +77,8 @@ Planning.propTypes = {
   search: PropTypes.string,
   categories: PropTypes.array,
   handleOnSearch: PropTypes.func,
-  getTargetMetaData: PropTypes.func
+  getTargetMetaData: PropTypes.func,
+  getSelectedCategoryTitle: PropTypes.func
 };
 
 export default Planning;

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -1,9 +1,12 @@
 import React, { PureComponent } from 'react';
+import cx from 'classnames';
 import Target from 'components/target';
 import Header from 'components/header';
 import PropTypes from 'prop-types';
 import Search from 'components/search';
+import Button from 'components/button';
 
+import yellowButtonTheme from 'styles/themes/button/button-yellow.scss';
 import styles from './planning-styles.scss';
 
 class Planning extends PureComponent {
@@ -15,24 +18,34 @@ class Planning extends PureComponent {
       search,
       getTargetMetaData
     } = this.props;
-    const isNotNdcTargetsCategory =
-      categories && selectedCategory && selectedCategory !== 'ndc_targets';
+    const hasAddTarget =
+      categories &&
+      selectedCategory &&
+      (selectedCategory === 'ndc_targets' ||
+        selectedCategory === 'user_defined_targets');
     return (
       categories && (
         <div className={styles.page}>
           <Header title="Planning" navSections={categories} />
-          {isNotNdcTargetsCategory && (
-            <div className={styles.actionsWrapper}>
-              <div className={styles.actions}>
-                <Search
-                  placeholder="Search something"
-                  value={search}
-                  onChange={handleOnSearch}
-                  className={styles.search}
-                />
-              </div>
+          <div className={styles.actionsWrapper}>
+            <div
+              className={cx(styles.actions, {
+                [styles.doubleAction]: hasAddTarget
+              })}
+            >
+              <Search
+                placeholder="Search something"
+                value={search}
+                onChange={handleOnSearch}
+                className={styles.search}
+              />
+              {hasAddTarget && (
+                <Button theme={yellowButtonTheme} link={'TODO'}>
+                  Add target
+                </Button>
+              )}
             </div>
-          )}
+          </div>
           <div className={styles.targetsContainer}>
             {categories &&
               selectedCategory &&

--- a/app/javascript/app/pages/planning/planning-component.jsx
+++ b/app/javascript/app/pages/planning/planning-component.jsx
@@ -44,7 +44,7 @@ class Planning extends PureComponent {
                 className={styles.search}
               />
               {hasAddTarget && (
-                <Button theme={yellowButtonTheme} link={'TODO'}>
+                <Button theme={yellowButtonTheme} disabled>
                   Add target
                 </Button>
               )}

--- a/app/javascript/app/pages/planning/planning-styles.scss
+++ b/app/javascript/app/pages/planning/planning-styles.scss
@@ -13,18 +13,10 @@
 .actions {
   @include row(3);
 
-  > :first-child {
-    @include column-offset(9, $gutters: true);
-  }
-
   padding-top: 10px;
   padding-bottom: 40px;
 }
 
 .doubleAction {
   @include row((3, 2));
-
-  > :first-child {
-    @include column-offset(7, $gutters: true);
-  }
 }

--- a/app/javascript/app/pages/planning/planning-styles.scss
+++ b/app/javascript/app/pages/planning/planning-styles.scss
@@ -20,3 +20,11 @@
   padding-top: 10px;
   padding-bottom: 40px;
 }
+
+.doubleAction {
+  @include row((3, 2));
+
+  > :first-child {
+    @include column-offset(7, $gutters: true);
+  }
+}

--- a/app/javascript/app/pages/planning/planning.js
+++ b/app/javascript/app/pages/planning/planning.js
@@ -35,10 +35,16 @@ class PlanningContainer extends PureComponent {
       return targetMetaDataField && targetMetaDataField.values[0].value;
     }
 
+    function getSelectedCategoryTitle(categories, selectedCategory) {
+      if (!categories || !selectedCategory) return null;
+      return categories.find(c => c.slug === selectedCategory).title;
+    }
+
     return createElement(PlanningComponent, {
       ...this.props,
       handleOnSearch,
-      getTargetMetaData
+      getTargetMetaData,
+      getSelectedCategoryTitle
     });
   }
 }

--- a/app/javascript/app/pages/planning/planning.js
+++ b/app/javascript/app/pages/planning/planning.js
@@ -28,6 +28,7 @@ class PlanningContainer extends PureComponent {
     };
 
     function getTargetMetaData(target, slug) {
+      if (!target || !target.indicators) return null;
       const targetMetaDataField = target.indicators.find(
         ind => ind.slug === slug
       );

--- a/app/javascript/app/pages/tracking/tracking-component.jsx
+++ b/app/javascript/app/pages/tracking/tracking-component.jsx
@@ -13,7 +13,8 @@ class Tracking extends PureComponent {
       selectedCategory,
       search,
       handleOnSearch,
-      handleYearChange
+      handleYearChange,
+      getSelectedCategoryTitle
     } = this.props;
     const isNotNdcTargetsCategory =
       categories && selectedCategory && selectedCategory !== 'ndc_targets';
@@ -41,7 +42,10 @@ class Tracking extends PureComponent {
             <div className={styles.actionsWrapper}>
               <div className={styles.actions}>
                 <Search
-                  placeholder="Search something"
+                  placeholder={`Filter ${getSelectedCategoryTitle(
+                    categories,
+                    selectedCategory
+                  )}`}
                   value={search}
                   onChange={handleOnSearch}
                   className={styles.search}
@@ -76,7 +80,8 @@ Tracking.propTypes = {
   search: PropTypes.string,
   selectedCategory: PropTypes.string,
   handleOnSearch: PropTypes.func.isRequired,
-  handleYearChange: PropTypes.func
+  handleYearChange: PropTypes.func,
+  getSelectedCategoryTitle: PropTypes.func
 };
 
 export default Tracking;

--- a/app/javascript/app/pages/tracking/tracking-styles.scss
+++ b/app/javascript/app/pages/tracking/tracking-styles.scss
@@ -13,10 +13,6 @@
 .actions {
   @include row(3);
 
-  > :first-child {
-    @include column-offset(9, $gutters: true);
-  }
-
   padding-top: 10px;
   padding-bottom: 40px;
 }

--- a/app/javascript/app/pages/tracking/tracking.js
+++ b/app/javascript/app/pages/tracking/tracking.js
@@ -28,10 +28,16 @@ class TrackingContainer extends PureComponent {
     };
     const handleYearChange = year => year; // TODO: Update year;
 
+    function getSelectedCategoryTitle(categories, selectedCategory) {
+      if (!categories || !selectedCategory) return null;
+      return categories.find(c => c.slug === selectedCategory).title;
+    }
+
     return createElement(TrackingComponent, {
       ...this.props,
       handleOnSearch,
-      handleYearChange
+      handleYearChange,
+      getSelectedCategoryTitle
     });
   }
 }

--- a/app/javascript/app/providers/sections.provider.js
+++ b/app/javascript/app/providers/sections.provider.js
@@ -5,7 +5,7 @@ const path =
 // Remove the force attribute when the reducers are updated and the data has only one source
 export async function getSectionsThunk(dispatch, getState, force = false) {
   const isSectionsEmpty = getState().sections.length === 0;
-  if (isSectionsEmpty || force) {
+  if (isSectionsEmpty || force === true) {
     dispatch(fetchSections());
   }
 }

--- a/app/javascript/app/styles/themes/button/button-yellow.scss
+++ b/app/javascript/app/styles/themes/button/button-yellow.scss
@@ -7,4 +7,8 @@
   &:hover {
     box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.09);
   }
+
+  &:disabled {
+    background-color: transparent;
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
       <%= stylesheet_pack_tag 'main' %>
     <% end %>
     <%= javascript_pack_tag 'main' %>
+    <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch,es6,Array.prototype.includes,String.prototype.includes"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This PR adds some missing search boxes according to latest designs
[Pivotal](https://www.pivotaltracker.com/story/show/158943468)
[Basecamp](https://basecamp.com/1756858/projects/13795275/todos/352469981)
[Designs](https://zpl.io/aN4747d)

Extra: 
-  Adds `Add target` button on `NDC targets` and `User defined targets` under `Planning` section. (the functionality is not yet implemented)
-  Updates search box placeholder text with category name.

![image](https://user-images.githubusercontent.com/6906348/42880302-18ac9fce-8a94-11e8-8171-84620e871875.png)
