### PR TITLE
Feature/admin can mark users as trusted

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -12,26 +12,24 @@ ActiveAdmin.register User do
   index do
     selectable_column
     id_column
-    column :is_admin
-    column :country_iso_code
-    column :email
     column :first_name
     column :last_name
+    column :email
+    column :country_iso_code
+    column :is_admin
     actions
   end
 
   filter :is_admin
-  filter :country_iso_code
+  filter :country_iso_code, as: :select
 
   form do |f|
     f.inputs 'User Details' do
-      if current_user.is_admin?
-        f.input :is_admin
-        f.input :country_iso_code
-      end
-      f.input :email
       f.input :first_name, as: :string
       f.input :last_name, as: :string
+      f.input :email
+      f.input :country_iso_code if current_user.is_admin?
+      f.input :is_admin if current_user.is_admin?
     end
     f.submit
   end
@@ -41,6 +39,16 @@ ActiveAdmin.register User do
       update! do |format|
         format.html { redirect_to edit_admin_user_path(@user) }
       end
+    end
+  end
+
+  show do
+    attributes_table do
+      row :first_name
+      row :last_name
+      row :email
+      row :country_iso_code
+      row :is_admin
     end
   end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register User do
     params = [
       :email, :first_name, :last_name, :password, :password_confirmation
     ]
-    params += [:is_admin, :country_iso_code] if current_user.is_admin?
+    params += [:status, :country_iso_code] if current_user.is_admin?
     params
   end
 
@@ -16,11 +16,11 @@ ActiveAdmin.register User do
     column :last_name
     column :email
     column :country_iso_code
-    column :is_admin
+    column :status
     actions
   end
 
-  filter :is_admin
+  filter :status, as: :select
   filter :country_iso_code, as: :select
 
   form do |f|
@@ -29,7 +29,7 @@ ActiveAdmin.register User do
       f.input :last_name, as: :string
       f.input :email
       f.input :country_iso_code if current_user.is_admin?
-      f.input :is_admin if current_user.is_admin?
+      f.input :status, as: :select, collection: User::STATUSES if current_user.is_admin?
     end
     f.submit
   end
@@ -48,7 +48,7 @@ ActiveAdmin.register User do
       row :last_name
       row :email
       row :country_iso_code
-      row :is_admin
+      row :status
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 class User < ApplicationRecord
   acts_as_token_authenticatable
 
+  ADMIN = 'ADMIN'
+  TRUSTED = 'TRUSTED'
+  USER = 'USER'
+
+  STATUSES = [ADMIN, TRUSTED, USER]
+
   devise :database_authenticatable,
          # :confirmable,
          :recoverable,
@@ -9,4 +15,9 @@ class User < ApplicationRecord
          :validatable
 
   validates :country_iso_code, presence: true, length: {is: 3}
+  validates :status, inclusion: { in: STATUSES }
+
+  def is_admin?
+    status == ADMIN
+  end
 end

--- a/db/migrate/20180727161213_change_is_admin_to_status.rb
+++ b/db/migrate/20180727161213_change_is_admin_to_status.rb
@@ -1,0 +1,14 @@
+class ChangeIsAdminToStatus < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :status, :text
+    execute "UPDATE users SET status = CASE WHEN is_admin THEN 'ADMIN' ELSE 'USER' END"
+    change_column :users, :status, :text, null: false, default: 'USER'
+    remove_column :users, :is_admin
+  end
+
+  def down
+    add_column :users, :is_admin, null: false, default: false
+    execute "UPDATE users SET is_admin = true WHERE status = 'ADMIN'"
+    remove_column :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180727153843) do
+ActiveRecord::Schema.define(version: 20180727161213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,7 +54,6 @@ ActiveRecord::Schema.define(version: 20180727153843) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
-    t.boolean "is_admin", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "encrypted_password", default: "", null: false
@@ -65,6 +64,7 @@ ActiveRecord::Schema.define(version: 20180727153843) do
     t.string "authentication_token", limit: 30
     t.text "first_name", null: false
     t.text "last_name", null: false
+    t.text "status", default: "USER", null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ if Rails.env.development?
     email: 'admin@example.com',
     first_name: 'Admin',
     last_name: 'User',
-    is_admin: true,
+    status: User::ADMIN,
     password: 'password',
     password_confirmation: 'password'
   )
@@ -20,7 +20,7 @@ if Rails.env.development?
     first_name: 'API user',
     last_name: 'Brazil',
     country_iso_code: 'BRA',
-    is_admin: false,
+    status: User::USER,
     password: 'password',
     password_confirmation: 'password'
   )

--- a/docs/tracking-tool-for-climate-watch/users.md
+++ b/docs/tracking-tool-for-climate-watch/users.md
@@ -28,13 +28,13 @@ curl "http://localhost:3000/users/sign_in" -X POST -d '{"user": {"email":"user@e
 {
    "id":2,
    "email":"user@example.com",
-   "is_admin":false,
    "created_at":"2018-07-30T09:36:44.058Z",
    "updated_at":"2018-07-30T09:36:44.058Z",
    "country_iso_code":"BRA",
    "authentication_token":"N37yhaWqyszDyHvBBxXX",
    "first_name":"API user",
-   "last_name":"Brazil"
+   "last_name":"Brazil",
+   "status":"USER"
 }
 ```
 
@@ -89,13 +89,13 @@ When the request is successful, the response includes the authentication token:
 {
    "id":3,
    "email":"user1@example.com",
-   "is_admin":false,
    "created_at":"2018-07-30T09:38:27.869Z",
    "updated_at":"2018-07-30T09:38:27.869Z",
    "country_iso_code":"XXX",
    "authentication_token":"nsoLo8nCFCDB1JWk3YPx",
    "first_name":"John",
-   "last_name":"Doe"
+   "last_name":"Doe",
+   "status":"USER"
 }
 ```
 
@@ -109,13 +109,13 @@ curl "http://localhost:3000/users/profile" -H "Content-Type: application/json" -
 {
    "id":2,
    "email":"user@example.com",
-   "is_admin":false,
    "created_at":"2018-07-30T09:36:44.058Z",
    "updated_at":"2018-07-30T09:36:44.058Z",
    "country_iso_code":"BRA",
    "authentication_token":"N37yhaWqyszDyHvBBxXX",
    "first_name":"API user",
-   "last_name":"Brazil"
+   "last_name":"Brazil",
+   "status":"USER"
 }
 ```
 

--- a/docs/tracking-tool-for-climate-watch/users.md
+++ b/docs/tracking-tool-for-climate-watch/users.md
@@ -1,8 +1,8 @@
 # User Management
 
-Users and Admins are stored in a single `users` table. Admin users are differentiated by having the `is_admin` flag set.
+Users, Trusted users and Admins are stored in a single `users` table. They are differentiated by having the `status` flag set to ADMIN, TRUSTED or USER respectively.
 
-Users and Admins can be managed via an admin tool powered by ActiveAdmin at `/admin`.
+Users can be managed via an admin tool powered by ActiveAdmin at `/admin`.
 
 ## Authentication
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     last_name 'Doe'
     sequence(:email) { |n| "person#{n}@example.com" }
     country_iso_code 'BRA'
-    is_admin false
+    status User::USER
     password 'password123'
   end
 end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -2,7 +2,7 @@ module UserHelpers
   def init_api_user
     before(:each) do
       @api_user ||= FactoryBot.create(
-        :user, country_iso_code: 'BRA', is_admin: false, password: 'foobar'
+        :user, country_iso_code: 'BRA', status: User::USER, password: 'foobar'
       )
     end
   end
@@ -10,7 +10,7 @@ module UserHelpers
   def init_admin
     before(:each) do
       @admin ||= FactoryBot.create(
-        :user, country_iso_code: 'BRA', is_admin: true
+        :user, country_iso_code: 'BRA', status: User::ADMIN
       )
     end
   end


### PR DESCRIPTION
Changes the boolean `is_admin` flag to a 3-values status field: ADMIN, TRUSTED, USER

For now `TRUSTED` doesn't do anything, but at some point this will be the required status to be able to publish a report.