### PR TITLE
Feature/devise paranoid mode

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,5 @@
+class Users::PasswordsController < Devise::PasswordsController
+  respond_to :json
+  protect_from_forgery with: :null_session,
+                       only: proc { |c| c.request.format.json? }
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -81,7 +81,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: 'users/sessions',
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    passwords: 'users/passwords'
   }.merge(ActiveAdmin::Devise.config)
 
   devise_scope :user do

--- a/docs/tracking-tool-for-climate-watch/users.md
+++ b/docs/tracking-tool-for-climate-watch/users.md
@@ -147,3 +147,10 @@ This will work:
 ```
 curl "http://localhost:3000/users" -X PUT -d '{"user": {"password":"new password", "current_password": "password"}}' -H "Content-Type: application/json" -H "Accept: application/json" -H "X-User-Email: user@example.com" -H "X-User-Token: N37yhaWqyszDyHvBBxXX"
 ```
+
+## Requesting forgotten password reset
+
+
+```
+curl "http://localhost:3000/users/password" -X POST -d '{"user": {"email":"user2@example.com"}}' -H "Content-Type: application/json" -H "Accept: application/json"
+```


### PR DESCRIPTION
Enables devise paranoid mode, which does the following:

```
  # It will change confirmation, password recovery and other workflows
  # to behave the same regardless if the e-mail provided was right or wrong.
  # Does not affect registerable.
```

It therefore won't confirm existence of email addresses when using the forgotten password feature; it doesn't, however, protect from the issue when self-registering accounts. Here is an explanation of the problem: https://github.com/plataformatec/devise/wiki/How-To:-Using-paranoid-mode,-avoid-user-enumeration-on-registerable

Also enables json responses in the passwords controller.